### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 Blitz is a native macOS app that gives AI agents full control over the iOS development lifecycle — simulator/iPhone management, database setup, and App Store Connect submission. It includes built-in MCP servers so Claude Code (or any MCP client) can build, test, and submit your app to the App Store.
 
+[![blitz-mcp MCP server](https://glama.ai/mcp/servers/blitzdotdev/blitz-mac/badges/card.svg)](https://glama.ai/mcp/servers/blitzdotdev/blitz-mac)
+
 <div align="center">
   <img src=".github/assets/before-after.png" width="800" />
 </div>


### PR DESCRIPTION
This PR adds a badge for the [blitz-mcp](https://glama.ai/mcp/servers/blitzdotdev/blitz-mac) server listing in Glama MCP server directory.

[![blitz-mcp MCP server](https://glama.ai/mcp/servers/blitzdotdev/blitz-mac/badges/card.svg)](https://glama.ai/mcp/servers/blitzdotdev/blitz-mac)

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.